### PR TITLE
'Enter Calorie' stores information of calories just once.

### DIFF
--- a/application.py
+++ b/application.py
@@ -125,7 +125,6 @@ def calories():
     """
     now = datetime.now()
     now = now.strftime('%Y-%m-%d')
-
     get_session = session.get('email')
     if get_session is not None:
         form = CalorieForm()
@@ -138,7 +137,7 @@ def calories():
                 print(cals)
                 burn = request.form.get('burnout')
 
-                temp = mongo.db.calories.find_one({'email': email}, {
+                temp = mongo.db.calories.find_one({'email': email, 'date': now}, {
                     'email', 'calories', 'burnout'})
                 if temp is not None:
                     mongo.db.calories.update({'email': email}, {'$set': {


### PR DESCRIPTION
If a user, on some date, records his calorie consumption and burnt calories, then the application stores it. But, if you want to store calorie data for the same user today, it doesn't create a new record with today's date. It just simply adds up the consumed calories and burnt calories to previous entry and old date is retained. So, history is not able to fetch today's calorie record, as there is no such record under today's date.
Fixed by changing the backend MongoDB structure to store each user's calorie data date-wise.